### PR TITLE
[codex] gate level-up studio behind character flows

### DIFF
--- a/src/App.css
+++ b/src/App.css
@@ -177,7 +177,8 @@
 }
 
 .character-create-form input,
-.character-create-form select {
+.character-create-form select,
+.character-create-form textarea {
     background: rgba(8, 15, 28, 0.85);
     border: 1px solid rgba(255, 255, 255, 0.14);
     border-radius: 12px;
@@ -186,8 +187,35 @@
     padding: 0 0.9rem;
 }
 
+.character-create-form textarea {
+    grid-column: 1 / -1;
+    min-height: 96px;
+    padding: 0.85rem 0.9rem;
+    resize: vertical;
+}
+
 .character-create-form .ability-score-grid {
     grid-column: 1 / -1;
+}
+
+.character-sheet-heading {
+    margin-bottom: 1.25rem;
+}
+
+.character-edit-panel {
+    margin-top: 1.5rem;
+}
+
+.character-edit-form .ability-score-grid,
+.currency-grid,
+.weapon-picker {
+    grid-column: 1 / -1;
+}
+
+.currency-grid {
+    display: grid;
+    gap: 0.75rem;
+    grid-template-columns: repeat(auto-fit, minmax(90px, 1fr));
 }
 
 .summary-stat-grid,

--- a/src/App.css
+++ b/src/App.css
@@ -267,6 +267,99 @@
     margin-top: 1rem;
 }
 
+.form-success {
+    color: #b7f0c1;
+    margin-top: 1rem;
+}
+
+.levelup-panel {
+    margin-top: 1.5rem;
+}
+
+.levelup-toolbar,
+.levelup-spell-grid {
+    display: grid;
+    gap: 1rem;
+    grid-template-columns: repeat(auto-fit, minmax(220px, 1fr));
+    margin-top: 1rem;
+}
+
+.levelup-actions {
+    display: flex;
+    flex-wrap: wrap;
+    gap: 0.75rem;
+}
+
+.levelup-level-card,
+.levelup-summary-card,
+.levelup-spell-group {
+    background: rgba(8, 15, 28, 0.45);
+    border: 1px solid rgba(255, 255, 255, 0.08);
+    border-radius: 16px;
+    padding: 1rem;
+}
+
+.levelup-summary-card {
+    display: flex;
+    flex-direction: column;
+    gap: 0.35rem;
+}
+
+.levelup-summary-card small,
+.levelup-group-header span,
+.spell-selector-copy small {
+    color: #c7c9d3;
+}
+
+.levelup-level-controls {
+    align-items: center;
+    display: flex;
+    gap: 0.75rem;
+}
+
+.levelup-level-controls input {
+    background: rgba(8, 15, 28, 0.85);
+    border: 1px solid rgba(255, 255, 255, 0.14);
+    border-radius: 12px;
+    color: #f8f1e0;
+    min-height: 46px;
+    padding: 0 0.9rem;
+    width: 88px;
+}
+
+.levelup-group-header {
+    display: flex;
+    flex-direction: column;
+    gap: 0.35rem;
+    margin-bottom: 0.85rem;
+}
+
+.spell-selector-list {
+    display: grid;
+    gap: 0.65rem;
+}
+
+.spell-selector-card {
+    align-items: flex-start;
+    background: rgba(255, 255, 255, 0.04);
+    border: 1px solid rgba(255, 255, 255, 0.08);
+    border-radius: 14px;
+    cursor: pointer;
+    display: flex;
+    gap: 0.75rem;
+    padding: 0.8rem 0.9rem;
+}
+
+.spell-selector-card input {
+    margin-top: 0.2rem;
+}
+
+.spell-selector-copy {
+    display: flex;
+    flex-direction: column;
+    gap: 0.2rem;
+}
+
 @media (max-width: 640px) {
     .character-card {
         align-items: flex-start;
@@ -275,7 +368,10 @@
     }
 
     .detail-list li,
-    .spell-card-header {
+    .spell-card-header,
+    .section-heading,
+    .levelup-actions,
+    .levelup-level-controls {
         align-items: flex-start;
         flex-direction: column;
         gap: 0.35rem;

--- a/src/lib/api.js
+++ b/src/lib/api.js
@@ -39,3 +39,8 @@ export async function fetchCharacterById(token, characterId) {
     const response = await axios.get(`${base}/player/${characterId}`, authConfig(token));
     return response.data.character;
 }
+
+export async function updateCharacter(token, characterId, payload) {
+    const response = await axios.put(`${base}/player/${characterId}`, payload, authConfig(token));
+    return response.data.character;
+}

--- a/src/pages/characters/CharactersPages.test.js
+++ b/src/pages/characters/CharactersPages.test.js
@@ -1,11 +1,12 @@
 import React from 'react';
-import { render, screen, waitFor } from '@testing-library/react';
+import { fireEvent, render, screen, waitFor, within } from '@testing-library/react';
 import { MemoryRouter, Route, Routes } from 'react-router-dom';
 import { vi } from 'vitest';
 
 import CharactersList from './charactersList';
 import PlayersCharacter from './playersCharacter';
 import {
+    updateCharacter,
     fetchCharacterById,
     fetchCharacters,
     fetchCompendiumBootstrap
@@ -21,7 +22,8 @@ vi.mock('../../lib/api', () => ({
     createCharacter: vi.fn(),
     fetchCharacterById: vi.fn(),
     fetchCharacters: vi.fn(),
-    fetchCompendiumBootstrap: vi.fn()
+    fetchCompendiumBootstrap: vi.fn(),
+    updateCharacter: vi.fn()
 }));
 
 beforeEach(() => {
@@ -52,6 +54,12 @@ test('renders compendium-backed character creation controls', async () => {
 });
 
 test('renders derived character detail sections', async () => {
+    fetchCompendiumBootstrap.mockResolvedValue({
+        spells: [
+            { id: 'fire-bolt', name: 'Fire Bolt', level: 0 },
+            { id: 'shield', name: 'Shield', level: 1 }
+        ]
+    });
     fetchCharacterById.mockResolvedValue({
         _id: 'character-1',
         characterName: 'Lia Stormwarden',
@@ -82,6 +90,11 @@ test('renders derived character detail sections', async () => {
         languages: ['Common', 'Elvish', 'Draconic'],
         armorId: null,
         shieldId: null,
+        spellcasting: { classId: 'wizard', ability: 'int', kind: 'prepared' },
+        availableSpellIds: ['fire-bolt', 'shield'],
+        cantripIds: ['fire-bolt'],
+        knownSpellIds: ['shield'],
+        preparedSpellIds: ['shield'],
         attacks: [{
             weaponId: 'light-crossbow',
             name: 'Light Crossbow',
@@ -125,5 +138,146 @@ test('renders derived character detail sections', async () => {
     expect(screen.getByText(/spell save dc/i)).toBeInTheDocument();
     expect(screen.getAllByText(/light crossbow/i).length).toBeGreaterThan(0);
     expect(screen.getByText(/sculpt spells/i)).toBeInTheDocument();
-    expect(screen.getByText(/fire bolt/i)).toBeInTheDocument();
+    expect(screen.getAllByText(/fire bolt/i).length).toBeGreaterThan(0);
+    expect(screen.getByRole('button', { name: /save level-up/i })).toBeInTheDocument();
+});
+
+test('saves level-up changes through the update character api', async () => {
+    fetchCompendiumBootstrap.mockResolvedValue({
+        spells: [
+            { id: 'fire-bolt', name: 'Fire Bolt', level: 0 },
+            { id: 'shield', name: 'Shield', level: 1 },
+            { id: 'fireball', name: 'Fireball', level: 3 }
+        ]
+    });
+    fetchCharacterById.mockResolvedValue({
+        _id: 'character-1',
+        characterName: 'Lia Stormwarden',
+        userName: 'Aria',
+        raceName: 'High Elf',
+        className: 'Wizard',
+        subclassName: 'School of Evocation',
+        level: 5,
+        background: 'Sage',
+        alignment: 'Neutral Good',
+        armorClass: 13,
+        currentHp: 22,
+        maxHp: 22,
+        initiative: 3,
+        speed: 30,
+        passivePerception: 13,
+        proficiencyBonus: 3,
+        spellSaveDC: 16,
+        spellAttackBonus: 8,
+        abilityScores: { str: 8, dex: 16, con: 13, int: 19, wis: 12, cha: 10 },
+        abilityMods: { str: -1, dex: 3, con: 1, int: 4, wis: 1, cha: 0 },
+        savingThrows: { str: -1, dex: 3, con: 1, int: 7, wis: 4, cha: 0 },
+        skillValues: { arcana: 7 },
+        savingThrowProficiencies: ['int', 'wis'],
+        skillProficiencies: ['arcana'],
+        weaponProficiencies: ['dagger'],
+        armorProficiencies: [],
+        languages: ['Common', 'Elvish'],
+        armorId: null,
+        shieldId: null,
+        spellcasting: { classId: 'wizard', ability: 'int', kind: 'prepared' },
+        availableSpellIds: ['fire-bolt', 'shield', 'fireball'],
+        cantripIds: ['fire-bolt'],
+        knownSpellIds: ['shield'],
+        preparedSpellIds: ['shield'],
+        attacks: [],
+        spellSlots: {
+            cantrips: ['fire-bolt'],
+            level_1: { slotTotal: 4, slotsExpended: 1 }
+        },
+        resolvedSpells: { cantrips: [], known: [], prepared: [] },
+        features: [{ id: 'sculpt-spells', name: 'Sculpt Spells' }],
+        currency: { cp: 0, sp: 0, ep: 0, gp: 73, pp: 0 },
+        traits: '',
+        ideals: '',
+        bonds: '',
+        flaws: ''
+    });
+    updateCharacter.mockResolvedValue({
+        _id: 'character-1',
+        characterName: 'Lia Stormwarden',
+        userName: 'Aria',
+        raceName: 'High Elf',
+        className: 'Wizard',
+        subclassName: 'School of Evocation',
+        level: 6,
+        background: 'Sage',
+        alignment: 'Neutral Good',
+        armorClass: 13,
+        currentHp: 27,
+        maxHp: 27,
+        initiative: 3,
+        speed: 30,
+        passivePerception: 13,
+        proficiencyBonus: 3,
+        spellSaveDC: 16,
+        spellAttackBonus: 8,
+        abilityScores: { str: 8, dex: 16, con: 13, int: 19, wis: 12, cha: 10 },
+        abilityMods: { str: -1, dex: 3, con: 1, int: 4, wis: 1, cha: 0 },
+        savingThrows: { str: -1, dex: 3, con: 1, int: 7, wis: 4, cha: 0 },
+        skillValues: { arcana: 7 },
+        savingThrowProficiencies: ['int', 'wis'],
+        skillProficiencies: ['arcana'],
+        weaponProficiencies: ['dagger'],
+        armorProficiencies: [],
+        languages: ['Common', 'Elvish'],
+        armorId: null,
+        shieldId: null,
+        spellcasting: { classId: 'wizard', ability: 'int', kind: 'prepared' },
+        availableSpellIds: ['fire-bolt', 'shield', 'fireball'],
+        cantripIds: ['fire-bolt'],
+        knownSpellIds: ['shield', 'fireball'],
+        preparedSpellIds: ['shield', 'fireball'],
+        attacks: [],
+        spellSlots: {
+            cantrips: ['fire-bolt'],
+            level_1: { slotTotal: 4, slotsExpended: 1 },
+            level_2: { slotTotal: 3, slotsExpended: 0 },
+            level_3: { slotTotal: 3, slotsExpended: 0 }
+        },
+        resolvedSpells: { cantrips: [], known: [], prepared: [] },
+        features: [{ id: 'sculpt-spells', name: 'Sculpt Spells' }],
+        currency: { cp: 0, sp: 12, ep: 0, gp: 73, pp: 0 },
+        traits: '',
+        ideals: '',
+        bonds: '',
+        flaws: ''
+    });
+
+    render(
+        <MemoryRouter initialEntries={['/characters/character-1']}>
+            <Routes>
+                <Route path="/characters/:characterId" element={<PlayersCharacter />} />
+            </Routes>
+        </MemoryRouter>
+    );
+
+    await waitFor(() => {
+        expect(screen.getByRole('heading', { name: /lia stormwarden/i })).toBeInTheDocument();
+    });
+
+    fireEvent.click(screen.getByRole('button', { name: /increase level/i }));
+
+    const knownGroup = screen.getByText(/known spells remain available for preparation/i).closest('.levelup-spell-group');
+    const preparedGroup = screen.getByText(/preparing a spell also adds it to known spells if needed/i).closest('.levelup-spell-group');
+
+    fireEvent.click(within(knownGroup).getByLabelText(/fireball/i));
+    fireEvent.click(within(preparedGroup).getByLabelText(/fireball/i));
+    fireEvent.click(screen.getByRole('button', { name: /save level-up/i }));
+
+    await waitFor(() => {
+        expect(updateCharacter).toHaveBeenCalledWith('test-token', 'character-1', {
+            level: 6,
+            cantripIds: ['fire-bolt'],
+            knownSpellIds: ['shield', 'fireball'],
+            preparedSpellIds: ['shield', 'fireball']
+        });
+    });
+
+    expect(screen.getByText(/character updated/i)).toBeInTheDocument();
 });

--- a/src/pages/characters/CharactersPages.test.js
+++ b/src/pages/characters/CharactersPages.test.js
@@ -6,6 +6,7 @@ import { vi } from 'vitest';
 import CharactersList from './charactersList';
 import PlayersCharacter from './playersCharacter';
 import {
+    createCharacter,
     updateCharacter,
     fetchCharacterById,
     fetchCharacters,
@@ -51,6 +52,44 @@ test('renders compendium-backed character creation controls', async () => {
     expect(screen.getAllByRole('combobox')).toHaveLength(3);
     expect(screen.getByPlaceholderText(/background/i)).toBeInTheDocument();
     expect(screen.getByDisplayValue('15')).toBeInTheDocument();
+});
+
+test('opens the level-up flow after creating a character', async () => {
+    fetchCharacters.mockResolvedValue([]);
+    fetchCompendiumBootstrap.mockResolvedValue({
+        races: [{ id: 'high-elf', name: 'High Elf' }],
+        classes: [{ id: 'wizard', name: 'Wizard' }],
+        subclasses: [{ id: 'evocation', classId: 'wizard', name: 'School of Evocation' }]
+    });
+    createCharacter.mockResolvedValue({
+        _id: 'new-character',
+        characterName: 'New Hero',
+        raceName: 'High Elf',
+        className: 'Wizard',
+        level: 1
+    });
+
+    render(
+        <MemoryRouter initialEntries={['/characters']}>
+            <Routes>
+                <Route path="/characters" element={<CharactersList />} />
+                <Route path="/characters/:characterId" element={<p>Level-up handoff</p>} />
+            </Routes>
+        </MemoryRouter>
+    );
+
+    await waitFor(() => {
+        expect(screen.getByRole('button', { name: /create character/i })).toBeInTheDocument();
+    });
+
+    fireEvent.change(screen.getByPlaceholderText(/character name/i), {
+        target: { value: 'New Hero' }
+    });
+    fireEvent.click(screen.getByRole('button', { name: /create character/i }));
+
+    await waitFor(() => {
+        expect(screen.getByText(/level-up handoff/i)).toBeInTheDocument();
+    });
 });
 
 test('renders derived character detail sections', async () => {
@@ -139,7 +178,9 @@ test('renders derived character detail sections', async () => {
     expect(screen.getAllByText(/light crossbow/i).length).toBeGreaterThan(0);
     expect(screen.getByText(/sculpt spells/i)).toBeInTheDocument();
     expect(screen.getAllByText(/fire bolt/i).length).toBeGreaterThan(0);
-    expect(screen.getByRole('button', { name: /save level-up/i })).toBeInTheDocument();
+    expect(screen.getByRole('button', { name: /level up/i })).toBeInTheDocument();
+    expect(screen.getByRole('button', { name: /edit character/i })).toBeInTheDocument();
+    expect(screen.queryByRole('button', { name: /save and apply/i })).not.toBeInTheDocument();
 });
 
 test('saves level-up changes through the update character api', async () => {
@@ -261,6 +302,7 @@ test('saves level-up changes through the update character api', async () => {
         expect(screen.getByRole('heading', { name: /lia stormwarden/i })).toBeInTheDocument();
     });
 
+    fireEvent.click(screen.getByRole('button', { name: /level up/i }));
     fireEvent.click(screen.getByRole('button', { name: /increase level/i }));
 
     const knownGroup = screen.getByText(/known spells remain available for preparation/i).closest('.levelup-spell-group');
@@ -268,7 +310,7 @@ test('saves level-up changes through the update character api', async () => {
 
     fireEvent.click(within(knownGroup).getByLabelText(/fireball/i));
     fireEvent.click(within(preparedGroup).getByLabelText(/fireball/i));
-    fireEvent.click(screen.getByRole('button', { name: /save level-up/i }));
+    fireEvent.click(screen.getByRole('button', { name: /save and apply/i }));
 
     await waitFor(() => {
         expect(updateCharacter).toHaveBeenCalledWith('test-token', 'character-1', {
@@ -279,5 +321,155 @@ test('saves level-up changes through the update character api', async () => {
         });
     });
 
-    expect(screen.getByText(/character updated/i)).toBeInTheDocument();
+    expect(screen.getByText(/character sheet updated/i)).toBeInTheDocument();
+});
+
+test('edits a character sheet and applies the update', async () => {
+    fetchCompendiumBootstrap.mockResolvedValue({
+        races: [{ id: 'high-elf', name: 'High Elf' }],
+        classes: [{ id: 'wizard', name: 'Wizard' }],
+        subclasses: [{ id: 'evocation', classId: 'wizard', name: 'School of Evocation' }],
+        weapons: [{ id: 'dagger', name: 'Dagger', category: 'simple-melee', weaponType: 'melee' }],
+        armor: [{ id: 'leather', name: 'Leather', category: 'light', baseAc: 11 }],
+        spells: []
+    });
+    fetchCharacterById.mockResolvedValue({
+        _id: 'character-1',
+        characterName: 'Lia Stormwarden',
+        userName: 'Aria',
+        raceId: 'high-elf',
+        raceName: 'High Elf',
+        classId: 'wizard',
+        className: 'Wizard',
+        subclassId: 'evocation',
+        subclassName: 'School of Evocation',
+        level: 5,
+        background: 'Sage',
+        alignment: 'Neutral Good',
+        armorClass: 13,
+        currentHp: 22,
+        maxHp: 22,
+        tempHp: 0,
+        initiative: 3,
+        speed: 30,
+        passivePerception: 13,
+        proficiencyBonus: 3,
+        spellSaveDC: 16,
+        spellAttackBonus: 8,
+        baseAbilityScores: { str: 8, dex: 14, con: 13, int: 18, wis: 12, cha: 10 },
+        abilityScores: { str: 8, dex: 16, con: 13, int: 19, wis: 12, cha: 10 },
+        abilityMods: { str: -1, dex: 3, con: 1, int: 4, wis: 1, cha: 0 },
+        savingThrows: { str: -1, dex: 3, con: 1, int: 7, wis: 4, cha: 0 },
+        skillValues: { arcana: 7 },
+        savingThrowProficiencies: ['int', 'wis'],
+        skillProficiencies: ['arcana'],
+        weaponProficiencies: ['dagger'],
+        armorProficiencies: ['light'],
+        languages: ['Common', 'Elvish'],
+        armorId: null,
+        shieldId: null,
+        equippedWeaponIds: [],
+        spellcasting: { classId: 'wizard', ability: 'int', kind: 'prepared' },
+        availableSpellIds: [],
+        cantripIds: [],
+        knownSpellIds: [],
+        preparedSpellIds: [],
+        attacks: [],
+        spellSlots: {},
+        resolvedSpells: { cantrips: [], known: [], prepared: [] },
+        features: [],
+        currency: { cp: 0, sp: 0, ep: 0, gp: 73, pp: 0 },
+        traits: '',
+        ideals: '',
+        bonds: '',
+        flaws: '',
+        backstory: ''
+    });
+    updateCharacter.mockResolvedValue({
+        _id: 'character-1',
+        characterName: 'Lia the Bold',
+        userName: 'Aria',
+        raceName: 'High Elf',
+        className: 'Wizard',
+        subclassName: 'School of Evocation',
+        level: 5,
+        background: 'Sage',
+        alignment: 'Neutral Good',
+        armorClass: 14,
+        currentHp: 20,
+        maxHp: 22,
+        initiative: 3,
+        speed: 30,
+        passivePerception: 13,
+        proficiencyBonus: 3,
+        spellSaveDC: 16,
+        spellAttackBonus: 8,
+        abilityScores: { str: 8, dex: 16, con: 13, int: 19, wis: 12, cha: 10 },
+        abilityMods: { str: -1, dex: 3, con: 1, int: 4, wis: 1, cha: 0 },
+        savingThrows: { str: -1, dex: 3, con: 1, int: 7, wis: 4, cha: 0 },
+        skillValues: { arcana: 7 },
+        savingThrowProficiencies: ['int', 'wis'],
+        skillProficiencies: ['arcana'],
+        weaponProficiencies: ['dagger'],
+        armorProficiencies: ['light'],
+        languages: ['Common', 'Elvish'],
+        armorId: 'leather',
+        shieldId: null,
+        equippedWeaponIds: ['dagger'],
+        spellcasting: { classId: 'wizard', ability: 'int', kind: 'prepared' },
+        availableSpellIds: [],
+        cantripIds: [],
+        knownSpellIds: [],
+        preparedSpellIds: [],
+        attacks: [],
+        spellSlots: {},
+        resolvedSpells: { cantrips: [], known: [], prepared: [] },
+        features: [],
+        currency: { cp: 0, sp: 0, ep: 0, gp: 74, pp: 0 },
+        traits: '',
+        ideals: '',
+        bonds: '',
+        flaws: '',
+        backstory: ''
+    });
+
+    render(
+        <MemoryRouter initialEntries={['/characters/character-1']}>
+            <Routes>
+                <Route path="/characters/:characterId" element={<PlayersCharacter />} />
+            </Routes>
+        </MemoryRouter>
+    );
+
+    await waitFor(() => {
+        expect(screen.getByRole('heading', { name: /lia stormwarden/i })).toBeInTheDocument();
+    });
+
+    fireEvent.click(screen.getByRole('button', { name: /edit character/i }));
+    fireEvent.change(screen.getByDisplayValue('Lia Stormwarden'), {
+        target: { value: 'Lia the Bold' }
+    });
+    fireEvent.change(screen.getByPlaceholderText(/current hp/i), {
+        target: { value: '20' }
+    });
+    fireEvent.change(screen.getByDisplayValue('73'), {
+        target: { value: '74' }
+    });
+    fireEvent.change(screen.getByDisplayValue('No armor'), {
+        target: { value: 'leather' }
+    });
+    fireEvent.click(screen.getByLabelText(/dagger/i));
+    fireEvent.click(screen.getByRole('button', { name: /save and apply/i }));
+
+    await waitFor(() => {
+        expect(updateCharacter).toHaveBeenCalledWith('test-token', 'character-1', expect.objectContaining({
+            characterName: 'Lia the Bold',
+            currentHp: 20,
+            armorId: 'leather',
+            equippedWeaponIds: ['dagger'],
+            currency: expect.objectContaining({ gp: 74 })
+        }));
+    });
+
+    expect(screen.getByText(/character sheet updated/i)).toBeInTheDocument();
 });

--- a/src/pages/characters/charactersList.js
+++ b/src/pages/characters/charactersList.js
@@ -1,4 +1,5 @@
 import React, { useEffect, useState } from 'react';
+import { useNavigate } from 'react-router-dom';
 
 import CharacterSheet from '../../components/characters/characterSheet';
 import { useAuth } from '../../context/auth';
@@ -51,6 +52,7 @@ export default function CharactersList() {
     const [isSaving, setIsSaving] = useState(false);
 
     const { token } = useAuth();
+    const navigate = useNavigate();
 
     useEffect(() => {
         let ignore = false;
@@ -126,6 +128,7 @@ export default function CharactersList() {
                 ...currentCharacters
             ]);
             setForm((currentForm) => syncFormWithCompendium(initialForm, compendium));
+            navigate(`/characters/${nextCharacter._id}?mode=levelUp`);
         } catch (requestError) {
             setError(requestError.response?.data?.error || 'Unable to create character.');
         } finally {

--- a/src/pages/characters/playersCharacter.js
+++ b/src/pages/characters/playersCharacter.js
@@ -1,5 +1,5 @@
 import React, { useEffect, useState } from 'react';
-import { Link, useParams } from 'react-router-dom';
+import { Link, useParams, useSearchParams } from 'react-router-dom';
 
 import { useAuth } from '../../context/auth';
 import { fetchCharacterById, fetchCompendiumBootstrap, updateCharacter } from '../../lib/api';
@@ -65,6 +65,52 @@ function syncPlanner(character) {
     };
 }
 
+function syncEditForm(character) {
+    return {
+        characterName: character?.characterName || '',
+        raceId: character?.raceId || '',
+        classId: character?.classId || '',
+        subclassId: character?.subclassId || '',
+        background: character?.background || '',
+        alignment: character?.alignment || '',
+        level: character?.level || 1,
+        baseAbilityScores: {
+            str: character?.baseAbilityScores?.str ?? character?.abilityScores?.str ?? 8,
+            dex: character?.baseAbilityScores?.dex ?? character?.abilityScores?.dex ?? 8,
+            con: character?.baseAbilityScores?.con ?? character?.abilityScores?.con ?? 8,
+            int: character?.baseAbilityScores?.int ?? character?.abilityScores?.int ?? 8,
+            wis: character?.baseAbilityScores?.wis ?? character?.abilityScores?.wis ?? 8,
+            cha: character?.baseAbilityScores?.cha ?? character?.abilityScores?.cha ?? 8
+        },
+        currentHp: character?.currentHp ?? '',
+        tempHp: character?.tempHp ?? 0,
+        armorId: character?.armorId || '',
+        shieldId: character?.shieldId || '',
+        equippedWeaponIds: character?.equippedWeaponIds || [],
+        currency: {
+            cp: character?.currency?.cp ?? 0,
+            sp: character?.currency?.sp ?? 0,
+            ep: character?.currency?.ep ?? 0,
+            gp: character?.currency?.gp ?? 0,
+            pp: character?.currency?.pp ?? 0
+        },
+        traits: character?.traits || '',
+        ideals: character?.ideals || '',
+        bonds: character?.bonds || '',
+        flaws: character?.flaws || '',
+        backstory: character?.backstory || ''
+    };
+}
+
+function toNumberOrUndefined(value) {
+    if (value === '' || value === null || value === undefined) {
+        return undefined;
+    }
+
+    const parsed = Number(value);
+    return Number.isFinite(parsed) ? parsed : undefined;
+}
+
 function SpellSelectionGroup({ title, description, options, selectedIds, onToggle }) {
     return (
         <div className="levelup-spell-group">
@@ -121,14 +167,25 @@ function SpellGroup({ title, spells, emptyCopy }) {
 
 export default function PlayersCharacter() {
     const [character, setCharacter] = useState(null);
-    const [compendium, setCompendium] = useState({ spells: [] });
+    const [compendium, setCompendium] = useState({
+        races: [],
+        classes: [],
+        subclasses: [],
+        weapons: [],
+        armor: [],
+        spells: []
+    });
     const [planner, setPlanner] = useState(syncPlanner(null));
+    const [editForm, setEditForm] = useState(syncEditForm(null));
+    const [mode, setMode] = useState('view');
     const [error, setError] = useState('');
     const [saveMessage, setSaveMessage] = useState('');
     const [isLoading, setIsLoading] = useState(true);
     const [isSaving, setIsSaving] = useState(false);
 
     const { characterId } = useParams();
+    const [searchParams] = useSearchParams();
+    const initialMode = searchParams.get('mode');
     const { token } = useAuth();
 
     useEffect(() => {
@@ -148,7 +205,14 @@ export default function PlayersCharacter() {
                 if (!ignore) {
                     setCharacter(nextCharacter);
                     setPlanner(syncPlanner(nextCharacter));
+                    setEditForm(syncEditForm(nextCharacter));
+                    setMode(initialMode === 'levelUp' ? 'levelUp' : 'view');
                     setCompendium({
+                        races: bootstrap.races || [],
+                        classes: bootstrap.classes || [],
+                        subclasses: bootstrap.subclasses || [],
+                        weapons: bootstrap.weapons || [],
+                        armor: bootstrap.armor || [],
                         spells: bootstrap.spells || []
                     });
                 }
@@ -168,7 +232,7 @@ export default function PlayersCharacter() {
         return () => {
             ignore = true;
         };
-    }, [characterId, token]);
+    }, [characterId, initialMode, token]);
 
     function toggleSelection(key, spellId) {
         setPlanner((currentPlanner) => {
@@ -201,6 +265,112 @@ export default function PlayersCharacter() {
         });
     }
 
+    function openEditMode() {
+        setEditForm(syncEditForm(character));
+        setMode('edit');
+        setError('');
+        setSaveMessage('');
+    }
+
+    function openLevelUpMode() {
+        setPlanner(syncPlanner(character));
+        setMode('levelUp');
+        setError('');
+        setSaveMessage('');
+    }
+
+    function closeActiveMode() {
+        setEditForm(syncEditForm(character));
+        setPlanner(syncPlanner(character));
+        setMode('view');
+        setError('');
+    }
+
+    function updateEditField(key, value) {
+        setEditForm((currentForm) => ({
+            ...currentForm,
+            [key]: value
+        }));
+    }
+
+    function updateAbilityScore(ability, value) {
+        setEditForm((currentForm) => ({
+            ...currentForm,
+            baseAbilityScores: {
+                ...currentForm.baseAbilityScores,
+                [ability]: value
+            }
+        }));
+    }
+
+    function updateCurrency(type, value) {
+        setEditForm((currentForm) => ({
+            ...currentForm,
+            currency: {
+                ...currentForm.currency,
+                [type]: value
+            }
+        }));
+    }
+
+    function toggleEquippedWeapon(weaponId) {
+        setEditForm((currentForm) => {
+            const isEquipped = currentForm.equippedWeaponIds.includes(weaponId);
+
+            return {
+                ...currentForm,
+                equippedWeaponIds: isEquipped
+                    ? currentForm.equippedWeaponIds.filter((value) => value !== weaponId)
+                    : [...currentForm.equippedWeaponIds, weaponId]
+            };
+        });
+    }
+
+    async function handleSaveEdit(event) {
+        event.preventDefault();
+        setIsSaving(true);
+        setError('');
+        setSaveMessage('');
+
+        try {
+            const nextCharacter = await updateCharacter(token, characterId, {
+                characterName: editForm.characterName,
+                raceId: editForm.raceId,
+                classId: editForm.classId,
+                subclassId: editForm.subclassId || undefined,
+                background: editForm.background,
+                alignment: editForm.alignment,
+                level: clampLevel(editForm.level),
+                baseAbilityScores: Object.fromEntries(
+                    Object.entries(editForm.baseAbilityScores).map(([ability, value]) => [ability, Number(value) || 0])
+                ),
+                currentHp: toNumberOrUndefined(editForm.currentHp),
+                tempHp: toNumberOrUndefined(editForm.tempHp) || 0,
+                armorId: editForm.armorId || null,
+                shieldId: editForm.shieldId || null,
+                equippedWeaponIds: editForm.equippedWeaponIds,
+                currency: Object.fromEntries(
+                    Object.entries(editForm.currency).map(([type, value]) => [type, Number(value) || 0])
+                ),
+                traits: editForm.traits,
+                ideals: editForm.ideals,
+                bonds: editForm.bonds,
+                flaws: editForm.flaws,
+                backstory: editForm.backstory
+            });
+
+            setCharacter(nextCharacter);
+            setPlanner(syncPlanner(nextCharacter));
+            setEditForm(syncEditForm(nextCharacter));
+            setMode('view');
+            setSaveMessage('Character sheet updated.');
+        } catch (requestError) {
+            setError(requestError.response?.data?.error || 'Unable to update character.');
+        } finally {
+            setIsSaving(false);
+        }
+    }
+
     async function handleSaveLevelUp() {
         setIsSaving(true);
         setError('');
@@ -216,7 +386,9 @@ export default function PlayersCharacter() {
 
             setCharacter(nextCharacter);
             setPlanner(syncPlanner(nextCharacter));
-            setSaveMessage('Character updated. Features, spell slots, and derived stats refreshed.');
+            setEditForm(syncEditForm(nextCharacter));
+            setMode('view');
+            setSaveMessage('Character sheet updated. Features, spell slots, and derived stats refreshed.');
         } catch (requestError) {
             setError(requestError.response?.data?.error || 'Unable to update character.');
         } finally {
@@ -255,12 +427,35 @@ export default function PlayersCharacter() {
     );
     const cantripOptions = availableSpells.filter((spell) => spell.level === 0);
     const leveledSpellOptions = availableSpells.filter((spell) => spell.level > 0);
+    const subclassOptions = compendium.subclasses.filter((subclass) => subclass.classId === editForm.classId);
+    const armorOptions = compendium.armor.filter((armor) => armor.category !== 'shield');
+    const shieldOptions = compendium.armor.filter((armor) => armor.category === 'shield');
 
     return (
         <section className="page-card character-detail-card">
-            <Link to="/characters" className="secondary-action">
-                Back to Characters
-            </Link>
+            <div className="section-heading character-sheet-heading">
+                <Link to="/characters" className="secondary-action">
+                    Back to Characters
+                </Link>
+                <div className="levelup-actions">
+                    <button
+                        type="button"
+                        className="secondary-action"
+                        onClick={openEditMode}
+                        disabled={isSaving || mode === 'edit'}
+                    >
+                        Edit Character
+                    </button>
+                    <button
+                        type="button"
+                        className="primary-action"
+                        onClick={openLevelUpMode}
+                        disabled={isSaving || mode === 'levelUp'}
+                    >
+                        Level Up
+                    </button>
+                </div>
+            </div>
             <h1>{character.characterName}</h1>
             <p className="character-subtitle">{subtitle || 'Unassigned adventurer'}</p>
             {saveMessage ? <p className="form-success">{saveMessage}</p> : null}
@@ -306,6 +501,176 @@ export default function PlayersCharacter() {
                 ) : null}
             </div>
 
+            {mode === 'edit' ? (
+                <form className="detail-panel character-edit-panel" onSubmit={handleSaveEdit}>
+                    <div className="section-heading">
+                        <div>
+                            <h3>Edit Character</h3>
+                            <p className="status-copy">Update sheet details, then save and apply to refresh derived stats.</p>
+                        </div>
+                        <div className="levelup-actions">
+                            <button type="button" className="secondary-action" onClick={closeActiveMode} disabled={isSaving}>
+                                Cancel
+                            </button>
+                            <button type="submit" className="primary-action" disabled={isSaving}>
+                                {isSaving ? 'Saving...' : 'Save and Apply'}
+                            </button>
+                        </div>
+                    </div>
+
+                    <div className="character-create-form character-edit-form">
+                        <input
+                            type="text"
+                            placeholder="Character Name"
+                            value={editForm.characterName}
+                            onChange={(event) => updateEditField('characterName', event.target.value)}
+                        />
+                        <select
+                            value={editForm.raceId}
+                            onChange={(event) => updateEditField('raceId', event.target.value)}
+                        >
+                            {compendium.races.map((race) => (
+                                <option key={race.id} value={race.id}>{race.name}</option>
+                            ))}
+                        </select>
+                        <select
+                            value={editForm.classId}
+                            onChange={(event) => {
+                                const nextClassId = event.target.value;
+                                const nextSubclasses = compendium.subclasses.filter((subclass) => subclass.classId === nextClassId);
+
+                                setEditForm((currentForm) => ({
+                                    ...currentForm,
+                                    classId: nextClassId,
+                                    subclassId: nextSubclasses[0]?.id || ''
+                                }));
+                            }}
+                        >
+                            {compendium.classes.map((classDoc) => (
+                                <option key={classDoc.id} value={classDoc.id}>{classDoc.name}</option>
+                            ))}
+                        </select>
+                        <select
+                            value={editForm.subclassId}
+                            onChange={(event) => updateEditField('subclassId', event.target.value)}
+                        >
+                            {subclassOptions.length === 0 ? <option value="">No subclass</option> : null}
+                            {subclassOptions.map((subclass) => (
+                                <option key={subclass.id} value={subclass.id}>{subclass.name}</option>
+                            ))}
+                        </select>
+                        <input
+                            type="number"
+                            min="1"
+                            max="20"
+                            placeholder="Level"
+                            value={editForm.level}
+                            onChange={(event) => updateEditField('level', event.target.value)}
+                        />
+                        <input
+                            type="text"
+                            placeholder="Background"
+                            value={editForm.background}
+                            onChange={(event) => updateEditField('background', event.target.value)}
+                        />
+                        <input
+                            type="text"
+                            placeholder="Alignment"
+                            value={editForm.alignment}
+                            onChange={(event) => updateEditField('alignment', event.target.value)}
+                        />
+                        <input
+                            type="number"
+                            placeholder="Current HP"
+                            value={editForm.currentHp}
+                            onChange={(event) => updateEditField('currentHp', event.target.value)}
+                        />
+                        <input
+                            type="number"
+                            placeholder="Temp HP"
+                            value={editForm.tempHp}
+                            onChange={(event) => updateEditField('tempHp', event.target.value)}
+                        />
+                        <select
+                            value={editForm.armorId}
+                            onChange={(event) => updateEditField('armorId', event.target.value)}
+                        >
+                            <option value="">No armor</option>
+                            {armorOptions.map((armor) => (
+                                <option key={armor.id} value={armor.id}>{armor.name}</option>
+                            ))}
+                        </select>
+                        <select
+                            value={editForm.shieldId}
+                            onChange={(event) => updateEditField('shieldId', event.target.value)}
+                        >
+                            <option value="">No shield</option>
+                            {shieldOptions.map((armor) => (
+                                <option key={armor.id} value={armor.id}>{armor.name}</option>
+                            ))}
+                        </select>
+
+                        <div className="ability-score-grid">
+                            {ABILITY_ORDER.map((ability) => (
+                                <label key={ability} className="ability-score-field">
+                                    <span>{ability.toUpperCase()}</span>
+                                    <input
+                                        type="number"
+                                        min="1"
+                                        max="30"
+                                        value={editForm.baseAbilityScores[ability]}
+                                        onChange={(event) => updateAbilityScore(ability, event.target.value)}
+                                    />
+                                </label>
+                            ))}
+                        </div>
+
+                        <div className="currency-grid">
+                            {CURRENCY_ORDER.map((type) => (
+                                <label key={type} className="ability-score-field">
+                                    <span>{type.toUpperCase()}</span>
+                                    <input
+                                        type="number"
+                                        min="0"
+                                        value={editForm.currency[type]}
+                                        onChange={(event) => updateCurrency(type, event.target.value)}
+                                    />
+                                </label>
+                            ))}
+                        </div>
+
+                        <div className="weapon-picker">
+                            <span className="detail-label">Equipped Weapons</span>
+                            <div className="spell-selector-list">
+                                {compendium.weapons.map((weapon) => (
+                                    <label key={weapon.id} className="spell-selector-card">
+                                        <input
+                                            type="checkbox"
+                                            checked={editForm.equippedWeaponIds.includes(weapon.id)}
+                                            onChange={() => toggleEquippedWeapon(weapon.id)}
+                                        />
+                                        <span className="spell-selector-copy">
+                                            <strong>{weapon.name}</strong>
+                                            <small>{formatSlug(weapon.category || weapon.weaponType)}</small>
+                                        </span>
+                                    </label>
+                                ))}
+                            </div>
+                        </div>
+
+                        {['traits', 'ideals', 'bonds', 'flaws', 'backstory'].map((field) => (
+                            <textarea
+                                key={field}
+                                placeholder={formatSlug(field)}
+                                value={editForm[field]}
+                                onChange={(event) => updateEditField(field, event.target.value)}
+                            />
+                        ))}
+                    </div>
+                </form>
+            ) : null}
+
+            {mode === 'levelUp' ? (
             <div className="detail-panel levelup-panel">
                 <div className="section-heading">
                     <div>
@@ -323,11 +688,19 @@ export default function PlayersCharacter() {
                         </button>
                         <button
                             type="button"
+                            className="secondary-action"
+                            onClick={closeActiveMode}
+                            disabled={isSaving}
+                        >
+                            Cancel
+                        </button>
+                        <button
+                            type="button"
                             className="primary-action"
                             onClick={handleSaveLevelUp}
                             disabled={isSaving}
                         >
-                            {isSaving ? 'Saving...' : 'Save Level-Up'}
+                            {isSaving ? 'Saving...' : 'Save and Apply'}
                         </button>
                     </div>
                 </div>
@@ -409,6 +782,7 @@ export default function PlayersCharacter() {
                     <p className="status-copy">This class does not use spell selection. Save to refresh level-based features and combat stats.</p>
                 )}
             </div>
+            ) : null}
 
             <div className="detail-panel">
                 <h3>Ability Scores</h3>

--- a/src/pages/characters/playersCharacter.js
+++ b/src/pages/characters/playersCharacter.js
@@ -2,7 +2,7 @@ import React, { useEffect, useState } from 'react';
 import { Link, useParams } from 'react-router-dom';
 
 import { useAuth } from '../../context/auth';
-import { fetchCharacterById } from '../../lib/api';
+import { fetchCharacterById, fetchCompendiumBootstrap, updateCharacter } from '../../lib/api';
 
 const ABILITY_ORDER = ['str', 'dex', 'con', 'int', 'wis', 'cha'];
 const CURRENCY_ORDER = ['cp', 'sp', 'ep', 'gp', 'pp'];
@@ -38,6 +38,62 @@ function formatRange(range) {
     return null;
 }
 
+function clampLevel(value) {
+    return Math.min(Math.max(Number(value) || 1, 1), 20);
+}
+
+function unique(values) {
+    return [...new Set((values || []).filter(Boolean))];
+}
+
+function sortSpells(spells) {
+    return [...spells].sort((left, right) => {
+        if (left.level !== right.level) {
+            return left.level - right.level;
+        }
+
+        return left.name.localeCompare(right.name);
+    });
+}
+
+function syncPlanner(character) {
+    return {
+        level: character?.level || 1,
+        cantripIds: character?.cantripIds || [],
+        knownSpellIds: character?.knownSpellIds || [],
+        preparedSpellIds: character?.preparedSpellIds || []
+    };
+}
+
+function SpellSelectionGroup({ title, description, options, selectedIds, onToggle }) {
+    return (
+        <div className="levelup-spell-group">
+            <div className="levelup-group-header">
+                <strong>{title}</strong>
+                <span>{description}</span>
+            </div>
+            {options.length === 0 ? <p className="status-copy">No spells available for this list.</p> : null}
+            {options.length > 0 ? (
+                <div className="spell-selector-list">
+                    {options.map((spell) => (
+                        <label key={spell.id} className="spell-selector-card">
+                            <input
+                                type="checkbox"
+                                checked={selectedIds.includes(spell.id)}
+                                onChange={() => onToggle(spell.id)}
+                            />
+                            <span className="spell-selector-copy">
+                                <strong>{spell.name}</strong>
+                                <small>{spell.level === 0 ? 'Cantrip' : `Level ${spell.level}`}</small>
+                            </span>
+                        </label>
+                    ))}
+                </div>
+            ) : null}
+        </div>
+    );
+}
+
 function SpellGroup({ title, spells, emptyCopy }) {
     return (
         <div className="detail-panel">
@@ -51,7 +107,7 @@ function SpellGroup({ title, spells, emptyCopy }) {
                                 <strong>{spell.name}</strong>
                                 <span>Level {spell.level}</span>
                             </div>
-                            <p>{spell.school} • {spell.range} • {spell.duration}</p>
+                            <p>{spell.school} | {spell.range} | {spell.duration}</p>
                             {spell.damageSummary ? <p>Effect: {spell.damageSummary}</p> : null}
                             {spell.attackType ? <p>Attack: {spell.attackType}</p> : null}
                             {spell.saveType ? <p>Save: {spell.saveType.toUpperCase()} vs DC {spell.spellSaveDC}</p> : null}
@@ -65,8 +121,12 @@ function SpellGroup({ title, spells, emptyCopy }) {
 
 export default function PlayersCharacter() {
     const [character, setCharacter] = useState(null);
+    const [compendium, setCompendium] = useState({ spells: [] });
+    const [planner, setPlanner] = useState(syncPlanner(null));
     const [error, setError] = useState('');
+    const [saveMessage, setSaveMessage] = useState('');
     const [isLoading, setIsLoading] = useState(true);
+    const [isSaving, setIsSaving] = useState(false);
 
     const { characterId } = useParams();
     const { token } = useAuth();
@@ -77,12 +137,20 @@ export default function PlayersCharacter() {
         async function loadCharacter() {
             setIsLoading(true);
             setError('');
+            setSaveMessage('');
 
             try {
-                const result = await fetchCharacterById(token, characterId);
+                const [nextCharacter, bootstrap] = await Promise.all([
+                    fetchCharacterById(token, characterId),
+                    fetchCompendiumBootstrap()
+                ]);
 
                 if (!ignore) {
-                    setCharacter(result);
+                    setCharacter(nextCharacter);
+                    setPlanner(syncPlanner(nextCharacter));
+                    setCompendium({
+                        spells: bootstrap.spells || []
+                    });
                 }
             } catch (requestError) {
                 if (!ignore) {
@@ -102,11 +170,65 @@ export default function PlayersCharacter() {
         };
     }, [characterId, token]);
 
+    function toggleSelection(key, spellId) {
+        setPlanner((currentPlanner) => {
+            const values = currentPlanner[key];
+            const isSelected = values.includes(spellId);
+            const nextValues = isSelected
+                ? values.filter((value) => value !== spellId)
+                : [...values, spellId];
+
+            if (key === 'knownSpellIds' && isSelected) {
+                return {
+                    ...currentPlanner,
+                    knownSpellIds: nextValues,
+                    preparedSpellIds: currentPlanner.preparedSpellIds.filter((value) => value !== spellId)
+                };
+            }
+
+            if (key === 'preparedSpellIds' && !isSelected && !currentPlanner.knownSpellIds.includes(spellId)) {
+                return {
+                    ...currentPlanner,
+                    knownSpellIds: [...currentPlanner.knownSpellIds, spellId],
+                    preparedSpellIds: [...currentPlanner.preparedSpellIds, spellId]
+                };
+            }
+
+            return {
+                ...currentPlanner,
+                [key]: nextValues
+            };
+        });
+    }
+
+    async function handleSaveLevelUp() {
+        setIsSaving(true);
+        setError('');
+        setSaveMessage('');
+
+        try {
+            const nextCharacter = await updateCharacter(token, characterId, {
+                level: clampLevel(planner.level),
+                cantripIds: planner.cantripIds,
+                knownSpellIds: planner.knownSpellIds,
+                preparedSpellIds: planner.preparedSpellIds
+            });
+
+            setCharacter(nextCharacter);
+            setPlanner(syncPlanner(nextCharacter));
+            setSaveMessage('Character updated. Features, spell slots, and derived stats refreshed.');
+        } catch (requestError) {
+            setError(requestError.response?.data?.error || 'Unable to update character.');
+        } finally {
+            setIsSaving(false);
+        }
+    }
+
     if (isLoading) {
         return <section className="page-card"><p className="status-copy">Loading character...</p></section>;
     }
 
-    if (error) {
+    if (error && !character) {
         return <section className="page-card"><p className="form-error">{error}</p></section>;
     }
 
@@ -116,12 +238,23 @@ export default function PlayersCharacter() {
 
     const subtitle = [character.raceName, character.className, character.subclassName]
         .filter(Boolean)
-        .join(' • ');
+        .join(' | ');
     const attacks = character.attacks || [];
     const cantrips = character.resolvedSpells?.cantrips || [];
     const knownSpells = character.resolvedSpells?.known || [];
     const preparedSpells = character.resolvedSpells?.prepared || [];
     const features = character.features || [];
+    const availableSpellIds = unique([
+        ...(character.availableSpellIds || []),
+        ...planner.cantripIds,
+        ...planner.knownSpellIds,
+        ...planner.preparedSpellIds
+    ]);
+    const availableSpells = sortSpells(
+        (compendium.spells || []).filter((spell) => availableSpellIds.includes(spell.id))
+    );
+    const cantripOptions = availableSpells.filter((spell) => spell.level === 0);
+    const leveledSpellOptions = availableSpells.filter((spell) => spell.level > 0);
 
     return (
         <section className="page-card character-detail-card">
@@ -130,6 +263,9 @@ export default function PlayersCharacter() {
             </Link>
             <h1>{character.characterName}</h1>
             <p className="character-subtitle">{subtitle || 'Unassigned adventurer'}</p>
+            {saveMessage ? <p className="form-success">{saveMessage}</p> : null}
+            {error ? <p className="form-error">{error}</p> : null}
+
             <div className="character-detail-grid">
                 <div>
                     <span className="detail-label">User</span>
@@ -168,6 +304,110 @@ export default function PlayersCharacter() {
                 {character.spellAttackBonus !== null && character.spellAttackBonus !== undefined ? (
                     <div className="summary-stat"><span className="detail-label">Spell Attack</span><strong>{formatModifier(character.spellAttackBonus)}</strong></div>
                 ) : null}
+            </div>
+
+            <div className="detail-panel levelup-panel">
+                <div className="section-heading">
+                    <div>
+                        <h3>Level-Up Studio</h3>
+                        <p className="status-copy">Adjust level, update spell picks, then save to re-derive the sheet.</p>
+                    </div>
+                    <div className="levelup-actions">
+                        <button
+                            type="button"
+                            className="secondary-action"
+                            onClick={() => setPlanner(syncPlanner(character))}
+                            disabled={isSaving}
+                        >
+                            Reset
+                        </button>
+                        <button
+                            type="button"
+                            className="primary-action"
+                            onClick={handleSaveLevelUp}
+                            disabled={isSaving}
+                        >
+                            {isSaving ? 'Saving...' : 'Save Level-Up'}
+                        </button>
+                    </div>
+                </div>
+
+                <div className="levelup-toolbar">
+                    <div className="levelup-level-card">
+                        <span className="detail-label">Level</span>
+                        <div className="levelup-level-controls">
+                            <button
+                                type="button"
+                                className="secondary-action"
+                                aria-label="Decrease level"
+                                onClick={() => setPlanner((currentPlanner) => ({
+                                    ...currentPlanner,
+                                    level: clampLevel(currentPlanner.level - 1)
+                                }))}
+                                disabled={isSaving || planner.level <= 1}
+                            >
+                                -
+                            </button>
+                            <input
+                                type="number"
+                                min="1"
+                                max="20"
+                                value={planner.level}
+                                onChange={(event) => setPlanner((currentPlanner) => ({
+                                    ...currentPlanner,
+                                    level: clampLevel(event.target.value)
+                                }))}
+                                aria-label="Character level"
+                            />
+                            <button
+                                type="button"
+                                className="secondary-action"
+                                aria-label="Increase level"
+                                onClick={() => setPlanner((currentPlanner) => ({
+                                    ...currentPlanner,
+                                    level: clampLevel(currentPlanner.level + 1)
+                                }))}
+                                disabled={isSaving || planner.level >= 20}
+                            >
+                                +
+                            </button>
+                        </div>
+                    </div>
+
+                    <div className="levelup-summary-card">
+                        <span className="detail-label">Current Sheet</span>
+                        <strong>HP {character.currentHp}/{character.maxHp}</strong>
+                        <small>Proficiency {formatModifier(character.proficiencyBonus)} | Spell DC {character.spellSaveDC ?? '--'}</small>
+                    </div>
+                </div>
+
+                {character.spellcasting?.ability ? (
+                    <div className="levelup-spell-grid">
+                        <SpellSelectionGroup
+                            title="Cantrips"
+                            description="Choose the cantrips you want on the sheet."
+                            options={cantripOptions}
+                            selectedIds={planner.cantripIds}
+                            onToggle={(spellId) => toggleSelection('cantripIds', spellId)}
+                        />
+                        <SpellSelectionGroup
+                            title="Known Spells"
+                            description="Known spells remain available for preparation."
+                            options={leveledSpellOptions}
+                            selectedIds={planner.knownSpellIds}
+                            onToggle={(spellId) => toggleSelection('knownSpellIds', spellId)}
+                        />
+                        <SpellSelectionGroup
+                            title="Prepared Spells"
+                            description="Preparing a spell also adds it to known spells if needed."
+                            options={leveledSpellOptions}
+                            selectedIds={planner.preparedSpellIds}
+                            onToggle={(spellId) => toggleSelection('preparedSpellIds', spellId)}
+                        />
+                    </div>
+                ) : (
+                    <p className="status-copy">This class does not use spell selection. Save to refresh level-based features and combat stats.</p>
+                )}
             </div>
 
             <div className="detail-panel">


### PR DESCRIPTION
## What changed
- hides Level-Up Studio during normal sheet viewing
- adds explicit Edit Character and Level Up modes on the character sheet
- opens newly-created characters directly into the level-up flow
- saves both edit and level-up selections through the existing update endpoint so the sheet is re-derived and refreshed
- adds client coverage for creation handoff, level-up save, and edit save

## Why
Level-Up Studio was always visible on an open character sheet. It now appears only during character creation handoff or intentional level-up, while character edits remain available anytime through a separate edit flow.

## Impact
Users can view sheets without the level-up controls, level up only when needed, and save/apply edits that refresh the full derived sheet.

## Validation
- npm.cmd test
- npm.cmd run build